### PR TITLE
add computing-101 mem-triple-deref transfer

### DIFF
--- a/computing-101/module.yml
+++ b/computing-101/module.yml
@@ -1,0 +1,13 @@
+name: Computing 101 Challenges
+description: |
+  Archived Computing 101 challenges.
+
+resources:
+  - id: mem-triple-deref
+    name: Triple Dereference
+    type: challenge
+    description: Follow pointers through three levels of dereference to reach the final value.
+    transfer:
+      dojo: computing-101
+      module: advanced-memory
+      challenge: mem-triple-deref

--- a/dojo.yml
+++ b/dojo.yml
@@ -13,6 +13,7 @@ modules:
 - id: talking-web
 - id: program-security
 - id: reverse-engineering
+- id: computing-101
 
 - id: web-security
   name: Web Security


### PR DESCRIPTION
## Summary
- add `computing-101` module to `dojo.yml`
- add `computing-101/module.yml`
- add `mem-triple-deref` challenge resource using a `transfer` block from `computing-101/advanced-memory/mem-triple-deref`

## Testing
- not run (metadata-only migration)
