### PR TITLE
add missing mem-triple-deref challenge files

### DIFF
--- a/computing-101/mem-triple-deref/.py/chal.py
+++ b/computing-101/mem-triple-deref/.py/chal.py
@@ -1,0 +1,214 @@
+import __main__ as checker
+import random
+import struct
+import time
+import re
+
+import chalconf #pylint:disable=import-error
+addr_chain = getattr(chalconf, 'addr_chain', None)
+secret_addr_reg = getattr(chalconf, 'secret_addr_reg', None)
+secret_value_reg = getattr(chalconf, 'secret_value_reg', None)
+value_offset = getattr(chalconf, 'value_offset', 0)
+num_instructions = getattr(chalconf, 'num_instructions', 3)
+final_reg_vals = getattr(chalconf, 'final_reg_vals', {})
+must_set_regs = getattr(chalconf, 'must_set_regs', [])
+must_get_regs = getattr(chalconf, 'must_get_regs', [])
+secret_checks = getattr(chalconf, 'secret_checks', ['exit'])
+secret_value = getattr(chalconf, 'secret_value', random.randint(15, 255))
+secret_value_desc = getattr(chalconf, 'secret_value_desc', f"value {secret_value}")
+clean_exit = getattr(chalconf, 'clean_exit', True)
+skip_deref_checks = getattr(chalconf, 'skip_deref_checks', False)
+exit_code = getattr(chalconf, 'exit_code', secret_value)
+stdin = getattr(chalconf, 'stdin', None)
+
+check_runtime_success = getattr(chalconf, "success_message", "Neat! Your program passed the tests! Great job!")
+
+#pylint:disable=global-statement
+
+allow_asm = True
+give_flag = True
+returncode = None
+
+assembly_prefix = ""
+mapped_pages = set()
+for n,_addr in enumerate(addr_chain):
+	_page = _addr - _addr%0x1000
+	assembly_prefix += "mov r9, 0x0; mov r8, 0xffffffff; mov r10, 0x32; mov rdx, 0x3; mov rsi, 0x1000;"
+	assembly_prefix += f"mov rdi, {_page}; mov rax, 9; syscall;\n"
+	try:
+		assembly_prefix += f"mov qword ptr [{_addr}], {addr_chain[n+1]}\n"
+	except IndexError:
+		if type(secret_value) is int:
+			assembly_prefix += f"mov qword ptr [{_addr+value_offset}], {secret_value}\n"
+		elif type(secret_value) is bytes:
+			for i,sb in enumerate(secret_value):
+				assembly_prefix += f"mov qword ptr [{_addr+value_offset+i}], {sb}\n"
+		else:
+			raise AssertionError("unexpected type for secret_value. Contact professors.") #pylint:disable=raise-missing-from
+
+if secret_addr_reg:
+	assembly_prefix += f"mov {secret_addr_reg}, {addr_chain[0]}\n"
+
+if secret_value_reg:
+	assembly_prefix += f"mov {secret_value_reg}, {secret_value}\n"
+
+if stdin is not None:
+	check_runtime_prologue = f"""
+Let's check what your output is! It should be our secret value, {stdin},
+as passed into the stdin of your program!
+	""".strip()
+elif secret_value_reg is not None:
+	check_runtime_prologue = f"""
+Let's check what your exit code is! It should be our secret
+value stored in register {secret_value_reg} ({secret_value_desc}) to succeed!
+	""".strip()
+elif secret_addr_reg and len(addr_chain) == 1:
+	check_runtime_prologue = f"""
+Let's check what your exit code is! It should be our secret
+value pointed to by {secret_addr_reg} ({secret_value_desc}) to succeed!
+	""".strip()
+elif secret_addr_reg:
+	check_runtime_prologue = f"""
+Let's check what your exit code is! It should be our secret
+value pointed to by a chain of pointers starting at {secret_addr_reg}!
+	""".strip()
+elif len(addr_chain) == 1:
+	check_runtime_prologue = f"""
+Let's check what your exit code is! It should be our secret value
+stored at memory address {addr_chain[-1]} ({secret_value_desc}) to succeed!
+	""".strip()
+else:
+	check_runtime_prologue = f"""
+Let's check what your exit code is! It should be our secret
+value pointed to by a chain of pointers starting at address {addr_chain[-1]}!
+	""".strip()
+
+def check_disassembly(disas):
+	mov_operands = [ d.op_str.split(", ") for d in disas if d.mnemonic == 'mov' ]
+
+	set_regs, get_args = zip(*mov_operands)
+	assert set(set_regs) >= set(must_set_regs), (
+		"You must set each of the following registers (using the mov instruction):\n    "+", ".join(must_set_regs)
+	)
+
+	assert set(get_args) >= set(must_get_regs), (
+		"You must get values from each of the following registers (using the\nmov instruction): "+", ".join(must_get_regs)
+	)
+
+	for r,vs in final_reg_vals.items():
+		v = vs
+		s = None
+		if type(vs) in (tuple,list):
+			v,s = vs
+		vv = hex(v) if v > 1 else str(v)
+		assert [r,vv] in mov_operands, (
+			f"You must properly set register {r} to the value {v}" +
+			(f" ({s})!" if s else "!")
+		)
+		last_mov_rax = max(i for i,m in enumerate(mov_operands) if m[0] == r)
+		last_val_set = len(mov_operands) - mov_operands[::-1].index([r, vv]) - 1
+		assert last_mov_rax <= last_val_set, (
+			f"You are overwriting the required value ({v}) that you need to put\n"
+			"into 'rax'. You can use 'rax' for other stuff, but make sure to move\n"
+			f"{v} into it afterwards!"
+		)
+
+	assert (not clean_exit) or mov_operands.index(['rax',"0x3c"]) == max(
+		i for i,m in enumerate(mov_operands) if m[0] == 'rax'
+	), (
+		"Uh oh! It looks like you're overwriting exit's syscall index (in rax) after\n"
+		"setting it. If you overwrite it, then your eventual syscall instruction will\n"
+		"trigger the wrong system call!"
+	)
+
+	if secret_addr_reg:
+		try:
+			idx_deref = max(i for i,m in enumerate(mov_operands) if secret_addr_reg in m[1] and "[" in m[1])
+		except ValueError as e:
+			raise AssertionError(
+				"It looks like you never dereference the register with the secret\n"
+				f"address ({secret_addr_reg})! You need to dereference it to read the\n"
+				"required exit code!"
+			) from e
+
+		try:
+			earliest_nonderef_overwrite = min(i for i,m in enumerate(mov_operands) if m[0] == secret_addr_reg and "[" not in m[1])
+			assert earliest_nonderef_overwrite >= idx_deref, (
+				f"Uh oh! It looks like you're overwriting the address in {secret_addr_reg} before\n"
+				"dereferencing it. Once you overwrite this value, you will lose the secret\n"
+				"address that we initialized it with! Dereference it first before overwriting\n"
+				"it.\n"
+			)
+		except ValueError:
+			pass
+
+	if not skip_deref_checks:
+		all_derefs = [ m for m in mov_operands if "[" in m[1] ]
+		for r,s in mov_operands:
+			if r == 'rax' and s == hex(60):
+				continue
+
+			if len(all_derefs) == len(addr_chain):
+				continue
+
+			if '[' not in s and s.startswith("0x"):
+				raise AssertionError(
+					f"In the line 'mov {r}, {int(s,16)}', you are moving the _value_ {int(s,16)} into\n"
+					f"{r}, rather than reading memory at the address {int(s,16)}. To read memory,\n"
+					f"you must enclose the value in [], such as: [{int(s,16)}]."
+				)
+			if '[' not in s and re.match(r"[a-zA-Z]*", s):
+				raise AssertionError(
+					f"In the line 'mov {r}, {s}', you are moving the _value_ in register\n"
+					f"{s} into {r}, rather than reading memory at the address pointed to by\n"
+					"{s}. To read memory, you must enclose the register in [], such as: [{s}]."
+				)
+
+	#first_str = f"dereference {secret_addr_reg}" if secret_addr_reg else f"load memory from {addr_chain[0]}"
+	#assert len(all_derefs) == len(addr_chain), (
+	#	f"To retrieve the secret value in this level, you must do {len(all_derefs)}\n"
+	#	"memory reads! First, " + first_str + "and then dereference the\n"
+	#	f"loaded value {len(addr_chain)-1} times!\n"
+	#) if len(addr_chain) > 1 else (
+	#	f"To retrieve the secret value in this level, you must\n"+first_str+"!"
+	#)
+
+	operation = disas[-1].mnemonic
+	assert operation == "syscall", (
+		"Your last instruction should be the 'syscall' instruction to invoke\n"
+		f"the exit system call, but you used the '{operation}' instruction!"
+	)
+
+	return True
+
+def check_runtime(filename):
+	global returncode
+	#pylint:disable=c-extension-no-member
+
+	try:
+		print("")
+		returncode = checker.dramatic_command(filename, stdin=stdin, actual_command = f"bash -c 'exec {filename} 2> >(tee /tmp/stderr 2>&1) > >(tee /tmp/stdout)'")
+		time.sleep(0.1)
+		for c in secret_checks:
+			if c == "cat":
+				actual_bytes = open(f"/tmp/stdout", "rb").read() #pylint:disable=consider-using-with,unspecified-encoding
+				assert actual_bytes == stdin, (
+					f"The value you wrote to stdout ({actual_bytes}) does not match the inputted value ({stdin})!"
+				)
+			if c in ["stdout", "stderr"]:
+				actual_bytes = open(f"/tmp/{c}", "rb").read() #pylint:disable=consider-using-with,unspecified-encoding
+				if type(secret_value) is int:
+					expected_bytes = struct.pack("<Q", secret_value).rstrip(b"\0")
+				elif type(secret_value) is bytes:
+					expected_bytes = secret_value
+				else:
+					raise AssertionError("unexpected type for secret_value. Contact professors.")
+				assert expected_bytes == actual_bytes, (
+					f"The value you wrote to {c} ({actual_bytes}) does not match the secret value ({expected_bytes})!"
+				)
+			if c == "exit":
+				checker.dramatic_command("echo $?", actual_command=f"echo {returncode}")
+				assert returncode == exit_code, f"Your program exited with the wrong error code (should be {exit_code})..."
+	finally:
+		checker.dramatic_command("")
+		print("")

--- a/computing-101/mem-triple-deref/.py/chalconf.py
+++ b/computing-101/mem-triple-deref/.py/chalconf.py
@@ -1,0 +1,11 @@
+import random
+
+addr_chain = [
+	random.randrange(0x1337000, 0x1338000),
+	random.randrange(0x123400, 0x123500),
+	random.randrange(0x100000, 0x101000)
+]
+secret_addr_reg = 'rdi'
+num_instructions = 5
+must_set_regs = [ "rax", "rdi" ]
+final_reg_vals = { "rax": 60 }

--- a/computing-101/mem-triple-deref/DESCRIPTION.md
+++ b/computing-101/mem-triple-deref/DESCRIPTION.md
@@ -1,0 +1,25 @@
+Okay, let's stretch that to one more depth!
+We've added an additional level of indirection in this challenge, so now you'll need *three* dereferences to find the secret value.
+Something like this:
+
+```text
+        Address │ Contents
+      +────────────────────+
+┌────▸│ 133700  │ 123400   │───┐
+│     +────────────────────+   │
+│ ┌──▸│ 123400  │ 100000   │─┐ │
+│ │   +────────────────────+ │ │
+│ │ ┌▸│ 100000  │ 42       │ │ │
+│ │ │ +────────────────────+ │ │
+│ │ └────────────────────────┘ │
+│ └────────────────────────────┘
+└──────────────────────────────┐
+                               │
+       Register │ Contents     │
+      +────────────────────+   │
+      │ rdi     │ 133700   │───┘
+      +────────────────────+
+```
+
+As you can see, we'll place the first address that you must dereference into rdi.
+Go get the value!

--- a/computing-101/mem-triple-deref/check
+++ b/computing-101/mem-triple-deref/check
@@ -1,0 +1,277 @@
+#!/usr/bin/exec-suid --real -- /bin/python3 -I
+
+import os
+os.environ["PATH"] = "/challenge/bin:/bin:/usr/bin:/usr/local/bin"
+os.environ["TERM"] = "xterm-256color"
+
+import pwnlib.context
+import pwnlib.tubes.process
+import pwnlib.asm
+import pwnlib.elf
+import contextlib
+import subprocess
+import capstone
+import tempfile
+import socket
+import magic
+import time
+import sys
+
+pwnlib.context.context.arch = "amd64"
+cs = capstone.Cs(capstone.CS_ARCH_X86, capstone.CS_MODE_64)
+
+sys.path.append(os.path.dirname(__file__)+"/.py")
+import chal #pylint:disable=import-error,wrong-import-position
+
+if os.geteuid() == 0:
+    os.seteuid(65534)
+
+class ChallengeFailed(Exception):
+    pass
+class ChallengeFailedPrint(ChallengeFailed):
+    pass
+
+def print_prompt():
+    print(f"""hacker@{socket.gethostname()}:{
+        os.getcwd().replace(os.path.expanduser('~'), '~', 1)
+    }$ """, end="", flush=True)
+
+def slow_pause():
+    if "FAST" not in os.environ:
+        time.sleep(0.05)
+
+def slow_print(what):
+    for c in what:
+        print(c, end="", flush=True)
+        slow_pause()
+    print("")
+
+def dramatic_command(command, stdin=None, actual_command=None):
+    print_prompt()
+    slow_print(command)
+    if not stdin:
+        exit_code = os.WEXITSTATUS(
+            os.system(command if actual_command is None else actual_command)
+        )
+    else:
+        p = pwnlib.tubes.process.process(
+            command if actual_command is None else actual_command,
+            shell=True
+        )
+        slow_pause()
+        slow_print(stdin.decode())
+        time.sleep(0.05)
+        p.write(stdin)
+        p.shutdown("send")
+        p.wait()
+        exit_code = p.poll()
+
+    slow_pause()
+    return exit_code
+
+@contextlib.contextmanager
+def disable_fd(fd):
+    bkup = os.dup(fd)
+    os.close(fd)
+    yield
+    os.dup2(bkup, fd)
+    os.close(bkup)
+
+def _assemble(asm):
+    with disable_fd(2):
+        return pwnlib.asm.asm(asm)
+
+def assemble(asm):
+    if not getattr(chal, "allow_asm", False):
+        raise ChallengeFailedPrint(
+            "This challenge requires you to assemble the code yourself. "
+            "Please do that."
+        )
+
+    try:
+        x86 = _assemble(asm)
+    except pwnlib.exception.PwnlibException as e:
+        errors = e.message.split("\n")
+        if (
+            errors[0].startswith("There was an error running") and
+            "Assembler messages" in errors[3]
+        ):
+            msg = "\n".join(
+                "- "+line.split(" ", 1)[-1]
+                for line in errors[4:]
+                if line
+            )
+            raise ChallengeFailedPrint(
+                f"Your assembly did not assemble cleanly. The errors:\n{msg}"
+            ) from e
+
+        raise ChallengeFailedPrint(
+            "Your assembly resulted in unexpected assembly errors:\n" +
+            e.message
+        ) from e
+
+    return x86
+
+def get_raw_binary(content):
+    m = magic.from_buffer(content)
+    if m == "ELF 64-bit relocatable":
+        raise ChallengeFailedPrint(
+            "You provided an ELF object file, rather than an actual\n"
+            "ELF executable. The object file is an intermediate result\n"
+            "of the compilation/assembly process. Please 'link' it into an\n"
+            "executable by using:\n"
+            "\n"
+            "hacker@dojo:~$ ld final.elf your-object-file.o"
+            "\n"
+            "This will create a 'final.elf' file that you can pass to this program!"
+        )
+    if (
+        "ELF 64-bit LSB shared object" in m or
+        "ELF 64-bit LSB pie executable" in m or
+        "ELF 64-bit LSB executable" in m
+    ):
+        if not getattr(chal, "allow_elf", True):
+            raise ChallengeFailedPrint(
+                "This challenge requires you to provide raw binary code, "
+                "but you provided an ELF. Please extract your .text segment "
+                "using 'objcopy'!"
+            )
+        tmpelf = tempfile.mktemp()
+        with open(tmpelf, "wb") as o:
+            o.write(content)
+        text = pwnlib.elf.ELF(tmpelf).get_section_by_name(".text")
+        if not text:
+            raise ChallengeFailedPrint(
+                "The ELF you provided is missing the .text section!"
+            )
+        rawbin = text.data()
+        if not rawbin:
+            raise ChallengeFailedPrint(
+                "The .text section of the ELF you provided is empty!"
+            )
+        return rawbin
+    elif "text" in m:
+        return assemble(content.decode('latin1')+"\n")
+    else: #assuming this is binary code
+        return content
+
+@contextlib.contextmanager
+def output_color(color, stream=sys.stdout):
+    CODES = {
+        'HEADER': '\033[95m',
+        'OKBLUE': '\033[94m',
+        'OKCYAN': '\033[96m',
+        'OKGREEN': '\033[92m',
+        'WARNING': '\033[93m',
+        'FAIL': '\033[91m',
+        'ENDC': '\033[0m',
+        'BOLD': '\033[1m',
+        'UNDERLINE': '\033[4m',
+    }
+    print(CODES[color.upper()], end="", flush=True, file=stream)
+    try:
+        yield
+    finally:
+        print(CODES['ENDC'], end="", flush=True, file=stream)
+
+def do_check(stage_id, stage_description, *args, **kwargs):
+    try:
+        if not hasattr(chal, stage_id):
+            return None
+
+        print("")
+        with output_color("header"):
+            print(getattr(chal, stage_id+"_prologue", f"{stage_description}...").format(**chal.__dict__))
+        r = getattr(chal, stage_id)(*args, **kwargs)
+        with output_color("okgreen"):
+            print(getattr(chal, stage_id+"_success", "... YES! Great job!").format(**chal.__dict__))
+        return r
+    except (ChallengeFailed, AssertionError) as _e:
+        with output_color("fail"):
+            print(getattr(chal, stage_id+"_failure", "... oops, we found an issue! Details below:\n").format(**chal.__dict__))
+            print(_e)
+        raise
+
+def main():
+    if len(sys.argv) == 2:
+        filename = sys.argv[1]
+        try:
+            #pylint:disable=consider-using-with,unspecified-encoding
+            content = open(filename, "rb").read()
+        except FileNotFoundError:
+            print(f"File {filename} not found.")
+            return
+        except PermissionError:
+            print(f"Permission denied when opening {filename}.")
+            return
+    elif not os.isatty(0):
+        content = sys.stdin.buffer.read()
+    else:
+        if chal.allow_asm:
+            print("Please input your assembly. Press Ctrl+D when done!")
+        else:
+            print(f"Please run this program as `{sys.argv[0]} your-program.elf`!")
+            sys.exit(1)
+        content = b""
+        while line := sys.stdin.buffer.readline():
+            content += line
+
+    raw_binary = get_raw_binary(content)
+
+    disas = list(cs.disasm(raw_binary, 0))
+    if not disas:
+        print("Your binary failed to disassemble.")
+        return
+
+    num_instructions = getattr(chal, "num_instructions", None)
+    if num_instructions is not None and len(disas) != num_instructions:
+        print(
+            f"This challenge expects {num_instructions} "
+            f"instruction{'s' if num_instructions != 1 else ''}, "
+            f"but you provided {len(disas)}."
+        )
+        return
+
+    if hasattr(chal, "assembly_prefix"):
+        binary_prefix = _assemble(chal.assembly_prefix)
+        raw_binary = binary_prefix + raw_binary
+    if hasattr(chal, "assembly_suffix"):
+        binary_suffix = _assemble(chal.assembly_suffix)
+        raw_binary = raw_binary + binary_suffix
+
+    do_check("check_raw_binary", "Checking the binary code", raw_binary)
+    do_check("check_disassembly", "Checking the assembly code", disas)
+
+    elf_filename = getattr(chal, 'final_filename', "/tmp/your-program")
+    os.rename(
+        pwnlib.asm.make_elf(raw_binary, extract=False),
+        elf_filename
+    )
+
+    if os.geteuid() == 65534:
+        os.seteuid(0)
+
+    do_check("check_runtime", "Checking runtime behavior", elf_filename)
+
+    if getattr(chal, "give_flag", False):
+        print("")
+        print("Here is your flag!")
+        #pylint:disable=consider-using-with,unspecified-encoding
+        print(open("/flag").read())
+
+
+if __name__ == '__main__':
+    try:
+        main()
+    except (ChallengeFailedPrint) as _e:
+        print("Check failed:")
+        print()
+        with output_color("FAIL"):
+            print(_e)
+    except (ChallengeFailed, AssertionError):
+        # we assume we already printed
+        pass
+    except Exception as _e: #pylint:disable=broad-exception-caught
+        print("Unexpected error during challenge evaluation! The error:")
+        print(_e)
+        raise


### PR DESCRIPTION
## Summary
- add `computing-101/mem-triple-deref/DESCRIPTION.md`
- add `computing-101/mem-triple-deref/check`
- add `computing-101/mem-triple-deref/.py/chalconf.py`
- add `computing-101/mem-triple-deref/.py/chal.py`

These are the archived challenge files that were missing from the transfer-only migration.

## Testing
- not run (file import only)
